### PR TITLE
Fix for ValueError: server_hostname 

### DIFF
--- a/smtptest.py
+++ b/smtptest.py
@@ -78,7 +78,7 @@ server = None
 if options.usessl:
 	server = smtplib.SMTP_SSL()
 else:
-	server = smtplib.SMTP()
+	server = smtplib.SMTP(host=serveraddr, port=options.serverport)
 
 server.set_debuglevel(options.debuglevel)
 server.connect(serveraddr, options.serverport)


### PR DESCRIPTION
A python3.7 bug, pass the hostname to smtplib.SMTP for fixing it.

https://github.com/ansible/ansible/pull/44552


Full Stacktrace:

`ling.com roman.shaikh@greyhoundrecycling.com smtp.office365.com
connect: ('smtp.office365.com', 587)
connect: to ('smtp.office365.com', 587) None
reply: b'220 LO2P123CA0016.outlook.office365.com Microsoft ESMTP MAIL Service ready at Tue, 7 Apr 2020 13:09:35 +0000\r\n'
reply: retcode (220); Msg: b'LO2P123CA0016.outlook.office365.com Microsoft ESMTP MAIL Service ready at Tue, 7 Apr 2020 13:09:35 +0000'
connect: b'LO2P123CA0016.outlook.office365.com Microsoft ESMTP MAIL Service ready at Tue, 7 Apr 2020 13:09:35 +0000'
send: 'ehlo LAPTOP-SL6JSTP1.Greyhound.local\r\n'
reply: b'250-LO2P123CA0016.outlook.office365.com Hello [109.255.38.119]\r\n'
reply: b'250-SIZE 157286400\r\n'
reply: b'250-PIPELINING\r\n'
reply: b'250-DSN\r\n'
reply: b'250-ENHANCEDSTATUSCODES\r\n'
reply: b'250-STARTTLS\r\n'
reply: b'250-8BITMIME\r\n'
reply: b'250-BINARYMIME\r\n'
reply: b'250-CHUNKING\r\n'
reply: b'250 SMTPUTF8\r\n'
reply: retcode (250); Msg: b'LO2P123CA0016.outlook.office365.com Hello [109.255.38.119]\nSIZE 157286400\nPIPELINING\nDSN\nENHANCEDSTATUSCODES\nSTARTTLS\n8BITMIME\nBINARYMIME\nCHUNKING\nSMTPUTF8'
send: 'STARTTLS\r\n'
reply: b'220 2.0.0 SMTP server ready\r\n'
reply: retcode (220); Msg: b'2.0.0 SMTP server ready'
Traceback (most recent call last):
  File "smtptest.py", line 86, in <module>
    if options.usetls: server.starttls()
  File "C:\Users\roman.shaikh.GREYHOUND\AppData\Local\Programs\Python\Python37\lib\smtplib.py", line 771, in starttls
    server_hostname=self._host)
  File "C:\Users\roman.shaikh.GREYHOUND\AppData\Local\Programs\Python\Python37\lib\ssl.py", line 423, in wrap_socket
    session=session
  File "C:\Users\roman.shaikh.GREYHOUND\AppData\Local\Programs\Python\Python37\lib\ssl.py", line 863, in _create
    owner=self, session=self._session,
ValueError: server_hostname cannot be an empty string or start with a leading dot.`