### PR TITLE
fixed error when use ssl

### DIFF
--- a/smtptest.py
+++ b/smtptest.py
@@ -76,7 +76,7 @@ if options.verbose:
 
 server = None
 if options.usessl:
-	server = smtplib.SMTP_SSL()
+	server = smtplib.SMTP_SSL(serveraddr)
 else:
 	server = smtplib.SMTP()
 


### PR DESCRIPTION
There was an error when we use -s or -usessl 
I have passed server address while initializing `smtplib.SMTP_SSL('youserver.com')`